### PR TITLE
 Replace $equation$ with images of rendered maths equations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,11 +64,11 @@ Spiking Video Streams
 ---------------------
 
 A traditional frame-based camera produces complete frames at some
-fixed time period ![delta_f](https://latex.codecogs.com/svg.latex?delta_f), so it produces a sequence of frames:
+fixed time period ![delta_f](https://latex.codecogs.com/svg.latex?\Delta_f), so it produces a sequence of frames:
 
 ![f_0, f_1, f_2, ...](https://latex.codecogs.com/svg.latex?f_0,f_1,f_2,\\&space;\hdots)
 
-where frame ![f_i](https://latex.codecogs.com/svg.latex?f_i) is associated with the relative time point ![i \times delta_f](https://latex.codecogs.com/svg.latex?i\times{delta_f}),
+where frame ![f_i](https://latex.codecogs.com/svg.latex?f_i) is associated with the relative time point ![i \times delta_f](https://latex.codecogs.com/svg.latex?i\times{\Delta_f}),
 and each frame is a ![w \times h \times c](https://latex.codecogs.com/svg.latex?w\times{h}\times{c}) tensor (well, technically a holor).
 Typically ![c=1](https://latex.codecogs.com/svg.latex?c=1) for gray-scale or ![c=3](https://latex.codecogs.com/svg.latex?c=3) for RGB or YUV.
 
@@ -96,12 +96,12 @@ The relative advantages of frame-based and event-based camers comes down
 to a tradeoff between:
 
 - latency: the frame-based camera has a fixed temporal resolution of
-  ![delta_f](https://latex.codecogs.com/svg.latex?delta_f),
+  ![delta_f](https://latex.codecogs.com/svg.latex?\Delta_f),
   while the temporal resolution of the event-based camera depends on how quickly
   pixels are changing, and how many pixels are changing.
 
 - bandwidth: the frame-based camera requires fixed band-width of
-  ![O( w \times h \times c / delta_f)](https://latex.codecogs.com/svg.latex?O(w\times{h}\times{c}/{delta_f}))
+  ![O( w \times h \times c / delta_f)](https://latex.codecogs.com/svg.latex?O(w\times{h}\times{c}/{\Delta_f}))
   while the event-based camera bandwidth varies with over time; between time points
   ![t_a](https://latex.codecogs.com/svg.latex?t_a) and
   ![t_b](https://latex.codecogs.com/svg.latex?t_b) the bandwidth will be proportional to

--- a/readme.md
+++ b/readme.md
@@ -64,27 +64,28 @@ Spiking Video Streams
 ---------------------
 
 A traditional frame-based camera produces complete frames at some
-fixed time period $delta_f$, so it produces a sequence of frames:
-```
-f_0, f_1, f_2, ...
-```
-where frame $f_i$ is associated with the relative time point $i*delta_f$,
-and each frame is a $w \times h \times c$ tensor (well, technically a holor).
-Typically $c=1$ for gray-scale or $c=3$ for RGB or YUV.
+fixed time period ![delta_f](https://latex.codecogs.com/svg.latex?delta_f), so it produces a sequence of frames:
+
+![f_0, f_1, f_2, ...](https://latex.codecogs.com/svg.latex?f_0,f_1,f_2,\\&space;\hdots)
+
+where frame ![f_i](https://latex.codecogs.com/svg.latex?f_i) is associated with the relative time point ![i \times delta_f](https://latex.codecogs.com/svg.latex?i\times{delta_f}),
+and each frame is a ![w \times h \times c](https://latex.codecogs.com/svg.latex?w\times{h}\times{c}) tensor (well, technically a holor).
+Typically ![c=1](https://latex.codecogs.com/svg.latex?c=1) for gray-scale or ![c=3](https://latex.codecogs.com/svg.latex?c=3) for RGB or YUV.
 
 The event based cameras being considered produce a stream of pixel events,
 which describe changes to pixel intensity at specific points in time. These
 events occur at a sequence of (non-strict) monotonically increasing
 time points, and each event carries an update to exactly one pixel. So we
 have a sequence of events:
-```
-e_0, e_1, e_2, ...
-```
-with each event a tuple $e_i=(t,x,y,v)$ where:
-- $t$ is when the event occurred
-- $(x,y)$ is the pixel co-ordinate being updated, with $0 \leq x < w$ and $0 \leq y < h$.
-- v is a $c$ component vector, e.g. for RGB is a 3-dimensional vector.
-Time monotonicity means that we should always have $i < j \implies t_i \leq t_j$.
+
+![e_0, e_1, e_2, ...](https://latex.codecogs.com/svg.latex?e_0,e_1,e_2,\\&space;\hdots)
+
+with each event a tuple ![e_i=(t,x,y,v)](https://latex.codecogs.com/svg.latex?e_i=(t,x,y,v)) where:
+- ![t](https://latex.codecogs.com/svg.latex?t) is when the event occurred
+- ![(x,y)](https://latex.codecogs.com/svg.latex?(x,y)) is the pixel co-ordinate being updated, with ![0 \leq x < w](https://latex.codecogs.com/svg.latex?0\leq{x}<w) and ![0 \leq y < h](https://latex.codecogs.com/svg.latex?0\leq{y}<h).
+- ![v](https://latex.codecogs.com/svg.latex?v) is a ![c](https://latex.codecogs.com/svg.latex?c) component vector, e.g. for RGB is a 3-dimensional vector.
+Time monotonicity means that we should always have
+![i < j \implies t_i \leq t_j](https://latex.codecogs.com/svg.latex?i<j\implies{t_i}\leq{t_j}).
 
 From the spike sequence we can convert back to complete frames at
 each discrete event time, though it would produce an extremely
@@ -94,14 +95,19 @@ high frame-rate stream with relatively low information content
 The relative advantages of frame-based and event-based camers comes down
 to a tradeoff between:
 
-- latency: the frame-based camera has a fixed temporal resolution of $delta_f$,
+- latency: the frame-based camera has a fixed temporal resolution of
+  ![delta_f](https://latex.codecogs.com/svg.latex?delta_f),
   while the temporal resolution of the event-based camera depends on how quickly
   pixels are changing, and how many pixels are changing.
 
-- bandwidth: the frame-based camera requires fixed band-width of $O( w \times h \times c / delta_f )$
+- bandwidth: the frame-based camera requires fixed band-width of
+  ![O( w \times h \times c / delta_f)](https://latex.codecogs.com/svg.latex?O(w\times{h}\times{c}/{delta_f}))
   while the event-based camera bandwidth varies with over time; between time points
-  $t_a$ and $t_b$ the bandwidth will be proportional to $| { e_i : t_a < t_i < t_b } | / (t_b-t_a)$,
-  i.e. the number of events between $t_a$ and $t_b$ divided by the time period.
+  ![t_a](https://latex.codecogs.com/svg.latex?t_a) and
+  ![t_b](https://latex.codecogs.com/svg.latex?t_b) the bandwidth will be proportional to
+  ![| { e_i : t_a < t_i < t_b } | / (t_b-t_a)](https://latex.codecogs.com/svg.latex?|e_i:t_a<t_i<t_b|\\&space;/\\&space;(t_b-t_a)),
+  i.e. the number of events between ![t_a](https://latex.codecogs.com/svg.latex?t_a)
+  and ![t_b](https://latex.codecogs.com/svg.latex?t_b) divided by the time period.
   Ultimately there will be some physical limit on bandwidth, and because each pixel
   event has higher overhead than a normal pixel (as it carries time and location, as well
   as value), the maximum events per second will be lower than the pixel rate of a frame camera.

--- a/readme.md
+++ b/readme.md
@@ -64,11 +64,11 @@ Spiking Video Streams
 ---------------------
 
 A traditional frame-based camera produces complete frames at some
-fixed time period ![delta_f](https://latex.codecogs.com/svg.latex?\Delta_f), so it produces a sequence of frames:
+fixed time period ![\Delta_f](https://latex.codecogs.com/svg.latex?\Delta_f), so it produces a sequence of frames:
 
 ![f_0, f_1, f_2, ...](https://latex.codecogs.com/svg.latex?f_0,f_1,f_2,\\&space;\hdots)
 
-where frame ![f_i](https://latex.codecogs.com/svg.latex?f_i) is associated with the relative time point ![i \times delta_f](https://latex.codecogs.com/svg.latex?i\times{\Delta_f}),
+where frame ![f_i](https://latex.codecogs.com/svg.latex?f_i) is associated with the relative time point ![i \times \Delta_f](https://latex.codecogs.com/svg.latex?i\times{\Delta_f}),
 and each frame is a ![w \times h \times c](https://latex.codecogs.com/svg.latex?w\times{h}\times{c}) tensor (well, technically a holor).
 Typically ![c=1](https://latex.codecogs.com/svg.latex?c=1) for gray-scale or ![c=3](https://latex.codecogs.com/svg.latex?c=3) for RGB or YUV.
 
@@ -96,12 +96,12 @@ The relative advantages of frame-based and event-based camers comes down
 to a tradeoff between:
 
 - latency: the frame-based camera has a fixed temporal resolution of
-  ![delta_f](https://latex.codecogs.com/svg.latex?\Delta_f),
+  ![\Delta_f](https://latex.codecogs.com/svg.latex?\Delta_f),
   while the temporal resolution of the event-based camera depends on how quickly
   pixels are changing, and how many pixels are changing.
 
 - bandwidth: the frame-based camera requires fixed band-width of
-  ![O( w \times h \times c / delta_f)](https://latex.codecogs.com/svg.latex?O(w\times{h}\times{c}/{\Delta_f}))
+  ![O( w \times h \times c / \Delta_f)](https://latex.codecogs.com/svg.latex?O(w\times{h}\times{c}/{\Delta_f}))
   while the event-based camera bandwidth varies with over time; between time points
   ![t_a](https://latex.codecogs.com/svg.latex?t_a) and
   ![t_b](https://latex.codecogs.com/svg.latex?t_b) the bandwidth will be proportional to


### PR DESCRIPTION
This PR replaces all instances of `$equation$` in the markdown with `![equation](https://latex.codecogs.com/svg.latex?equation)` in order to show the rendered latex math equation rather than the code for it, keeping the original as alt text (even though it seems alt text does not show up when hovering over the text).

Unfortunately, this makes it a bit more tedious to just read the .md file in a text editor, however it makes the experience of reading the spec much nicer in the we browser (which I believe is much more common) and when necessary, `sed -i'' -E "s/!\[(.+)]\(https:..latex.+\)/$\1$"` can revert the changes.

A [preview](https://github.com/Faboor/hpce-2018-cw6/blob/spec_equations/readme.md) is available in the fork.